### PR TITLE
Addressing Missing 'sql' Parameter in generate_followup_questions Method

### DIFF
--- a/app.py
+++ b/app.py
@@ -170,7 +170,7 @@ def add_training_data():
 
 @app.route('/api/v0/generate_followup_questions', methods=['GET'])
 @requires_cache(['df', 'question', 'sql'])
-def generate_followup_questions(id: str, df, sql, question):
+def generate_followup_questions(id: str, df, question, sql):
     followup_questions = vn.generate_followup_questions(question=question, sql=sql, df=df)
 
     cache.set(id=id, field='followup_questions', value=followup_questions)

--- a/app.py
+++ b/app.py
@@ -169,9 +169,9 @@ def add_training_data():
         return jsonify({"type": "error", "error": str(e)})
 
 @app.route('/api/v0/generate_followup_questions', methods=['GET'])
-@requires_cache(['df', 'question'])
-def generate_followup_questions(id: str, df, question):
-    followup_questions = vn.generate_followup_questions(question=question, df=df)
+@requires_cache(['df', 'question', 'sql'])
+def generate_followup_questions(id: str, df, sql, question):
+    followup_questions = vn.generate_followup_questions(question=question, sql=sql, df=df)
 
     cache.set(id=id, field='followup_questions', value=followup_questions)
 


### PR DESCRIPTION
Within the app.py file, the generate_followup_questions method encounters an issue when executing SQL queries and attempting to generate follow-up questions via the /api/v0/generate_followup_questions endpoint. The error is coming because the absence of the 'sql' parameter, which is required for vn.generate_followup_questions() method. 